### PR TITLE
Normalize pricing dataset and add schema validation

### DIFF
--- a/.github/workflows/validate-pricing.yml
+++ b/.github/workflows/validate-pricing.yml
@@ -1,0 +1,19 @@
+name: Validate pricing data
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Validate pricing.json
+        run: npm run validate:pricing
+      - name: Run tests
+        run: npm test

--- a/index.html
+++ b/index.html
@@ -3,40 +3,63 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Azure Databricks pricing Orange</title>
+  <title>Azure Databricks Pricing Orange</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <header>
     <div class="logo">O</div>
     <div>
-      <h1>Azure Databricks pricing Orange</h1>
-      <p>外部 JSON から料金データを読み込むサンプル</p>
+      <h1>Azure Databricks Pricing Orange</h1>
+      <p>DBU プラットフォーム費用の概算を正規化データから算出します。</p>
+      <div class="pricing-meta" id="pricingMeta">
+        <span class="badge" id="pricingVersion">version --</span>
+        <span class="badge" id="pricingCurrency">currency --</span>
+      </div>
     </div>
   </header>
 
   <main>
+    <div id="bannerContainer"></div>
+
     <section class="card" aria-labelledby="calcTitle">
       <h2 id="calcTitle">見積条件</h2>
+
       <div class="form-row" style="margin-top:12px;">
         <div class="col">
-          <label for="workload">ワークロード</label>
-          <select id="workload"></select>
+          <label for="serviceSelect">サービス</label>
+          <select id="serviceSelect"></select>
         </div>
-
         <div class="col">
-          <label for="instanceType">インスタンスタイプ</label>
-          <select id="instanceType"></select>
+          <label for="editionSelect">エディション</label>
+          <select id="editionSelect"></select>
         </div>
-
         <div class="col">
-          <label for="clusterSize">クラスター サイズ（ノード数）</label>
-          <select id="clusterSize"></select>
+          <label for="regionSelect">リージョン</label>
+          <select id="regionSelect"></select>
         </div>
-
         <div class="col">
-          <label for="hours">処理時間（時間）</label>
-          <input id="hours" type="number" min="0" step="0.25" value="1" />
+          <label for="serverlessSelect">Serverless</label>
+          <select id="serverlessSelect"></select>
+        </div>
+      </div>
+
+      <div class="form-row" style="margin-top:12px;">
+        <div class="col">
+          <label for="dbuInput">月間 DBU 消費量</label>
+          <input id="dbuInput" type="number" min="0" step="1" value="1000" />
+        </div>
+        <div class="col">
+          <label>選択中の DBU 単価</label>
+          <div class="metric" id="selectedRate">-- USD/DBU</div>
+        </div>
+        <div class="col">
+          <label>適用開始日</label>
+          <div class="metric" id="effectiveDate">--</div>
+        </div>
+        <div class="col">
+          <label>出典</label>
+          <div class="metric" id="sourceLink">--</div>
         </div>
       </div>
 
@@ -48,33 +71,30 @@
       <div class="card" style="margin-top:14px;">
         <div class="result">
           <div>
-            <div class="price" id="totalPrice">¥0</div>
+            <div class="price" id="totalPrice">$0.00</div>
             <div class="breakdown" id="breakdownText">-- 内訳</div>
-          </div>
-          <div style="min-width:220px;">
-            <label>想定リージョン</label>
-            <select id="region"></select>
           </div>
         </div>
       </div>
 
       <p style="margin-top:12px;font-size:13px;color:var(--muted);">
-        ※このツールは簡易見積もりです。正確な料金は Azure ポータルの料金ページおよび契約条件に基づきます。
+        ※DBU は Databricks のプラットフォーム課金です。VM やストレージ等のインフラ費用は別途加算されます。
       </p>
     </section>
 
     <section class="card">
-      <h2>計算式（簡易モデル）</h2>
+      <h2>計算式（DBU 部分）</h2>
       <p class="breakdown">
-        $$Total = (DBU\_rate \times DBU\_count + VM\_hourly\_rate \times nodes) \times hours$$
+        $$Total = DBU\_rate \times DBU\_usage$$
       </p>
+      <p class="breakdown" id="recordNotes"></p>
     </section>
   </main>
 
   <footer>
-    参考: Azure Databricks の料金（概算）— 実際の料金は公式ページを確認してください。
+    出典と適用開始日は pricing.json に記載の一次情報を参照しています。
   </footer>
 
-  <script src="main.js"></script>
+  <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,137 +1,303 @@
-let pricingData = null;
+import { loadPricingData, summarizeIssues } from './src/pricing-loader.js';
 
-// DOM 要素
-const workloadEl = document.getElementById('workload');
-const instanceEl = document.getElementById('instanceType');
-const clusterEl = document.getElementById('clusterSize');
-const hoursEl = document.getElementById('hours');
-const regionEl = document.getElementById('region');
+const bannerContainer = document.getElementById('bannerContainer');
+const versionBadge = document.getElementById('pricingVersion');
+const currencyBadge = document.getElementById('pricingCurrency');
+const serviceSelect = document.getElementById('serviceSelect');
+const editionSelect = document.getElementById('editionSelect');
+const regionSelect = document.getElementById('regionSelect');
+const serverlessSelect = document.getElementById('serverlessSelect');
+const dbuInput = document.getElementById('dbuInput');
+const selectedRateEl = document.getElementById('selectedRate');
+const effectiveDateEl = document.getElementById('effectiveDate');
+const sourceLinkEl = document.getElementById('sourceLink');
+const recordNotesEl = document.getElementById('recordNotes');
 const totalPriceEl = document.getElementById('totalPrice');
 const breakdownEl = document.getElementById('breakdownText');
 const calcBtn = document.getElementById('calcBtn');
 const resetBtn = document.getElementById('resetBtn');
 
-function formatYen(val){
-  return '¥' + Number(val).toLocaleString('ja-JP', {maximumFractionDigits:0});
+const UI_STATE_KEY = 'orange:ui-state';
+
+let pricingData = null;
+let currentRecord = null;
+let metadata = null;
+
+const filterState = {
+  service: '',
+  edition: '',
+  region: '',
+  serverless: ''
+};
+
+function saveUiState() {
+  try {
+    const payload = {
+      filters: filterState,
+      dbuUsage: Number.parseFloat(dbuInput.value) || 0
+    };
+    window.localStorage.setItem(UI_STATE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.warn('failed to store UI state', error);
+  }
 }
 
-function loadPricing(){
-  return fetch('pricing.json')
-    .then(resp => {
-      if (!resp.ok) throw new Error('pricing.json を取得できません: ' + resp.status);
-      return resp.json();
-    })
-    .then(json => {
-      pricingData = json;
-      populateControls();
-      calculate(); // 初期計算
-    })
-    .catch(err => {
-      console.error(err);
-      breakdownEl.textContent = '料金データの読み込みに失敗しました。コンソールを確認してください。';
-    });
+function restoreUiState() {
+  try {
+    const raw = window.localStorage.getItem(UI_STATE_KEY);
+    if (!raw) {
+      return;
+    }
+    const parsed = JSON.parse(raw);
+    if (parsed && parsed.filters) {
+      filterState.service = parsed.filters.service || '';
+      filterState.edition = parsed.filters.edition || '';
+      filterState.region = parsed.filters.region || '';
+      filterState.serverless = parsed.filters.serverless || '';
+    }
+    if (parsed && typeof parsed.dbuUsage === 'number' && Number.isFinite(parsed.dbuUsage)) {
+      dbuInput.value = parsed.dbuUsage;
+    }
+  } catch (error) {
+    console.warn('failed to restore UI state', error);
+  }
 }
 
-function populateControls(){
-  // ワークロード
-  workloadEl.innerHTML = '';
-  for (const key of Object.keys(pricingData.workloads)) {
-    const opt = document.createElement('option');
-    opt.value = key;
-    opt.textContent = pricingData.workloads[key].label || key;
-    workloadEl.appendChild(opt);
-  }
-
-  // インスタンスタイプ
-  instanceEl.innerHTML = '';
-  for (const key of Object.keys(pricingData.instances)) {
-    const opt = document.createElement('option');
-    opt.value = key;
-    opt.textContent = pricingData.instances[key].label || key;
-    instanceEl.appendChild(opt);
-  }
-
-  // クラスターサイズ
-  clusterEl.innerHTML = '';
-  for (const key of Object.keys(pricingData.clusters)) {
-    const opt = document.createElement('option');
-    opt.value = key;
-    opt.textContent = `${pricingData.clusters[key].label} — ${pricingData.clusters[key].nodes} ノード`;
-    clusterEl.appendChild(opt);
-  }
-
-  // リージョン
-  regionEl.innerHTML = '';
-  for (const key of Object.keys(pricingData.regions)) {
-    const opt = document.createElement('option');
-    opt.value = key;
-    opt.textContent = pricingData.regions[key].label;
-    regionEl.appendChild(opt);
-  }
-
-  // 初期値選択（任意）
-  workloadEl.value = Object.keys(pricingData.workloads)[0];
-  instanceEl.value = Object.keys(pricingData.instances)[0];
-  clusterEl.value = Object.keys(pricingData.clusters)[0];
-  regionEl.value = Object.keys(pricingData.regions)[0];
+function formatCurrency(amount) {
+  const currency = metadata?.currency || 'USD';
+  const formatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  });
+  return formatter.format(amount);
 }
 
-function calculate(){
-  if (!pricingData) {
-    breakdownEl.textContent = '料金データがロードされていません';
+function setBadgeText(element, label, value) {
+  if (!element) return;
+  if (!value) {
+    element.textContent = `${label} --`;
     return;
   }
-
-  const workloadKey = workloadEl.value;
-  const instanceKey = instanceEl.value;
-  const clusterKey = clusterEl.value;
-  const regionKey = regionEl.value;
-  const hours = Math.max(0, parseFloat(hoursEl.value) || 0);
-
-  const cluster = pricingData.clusters[clusterKey];
-  const instance = pricingData.instances[instanceKey];
-  const workload = pricingData.workloads[workloadKey];
-  const region = pricingData.regions[regionKey];
-
-  const nodes = cluster.nodes;
-  const dbuPerNode = instance.dbu_per_node || 1;
-
-  // DBU 単価（インスタンスタイプ別）。もし workload に該当する dbu_rates に instanceKey がなければエラーハンドリング
-  const dbuRateUSD = (workload.dbu_rates && workload.dbu_rates[instanceKey]) || 0;
-  const vmRateUSD = instance.vm_rate || 0;
-
-  // DBU の総数（単純モデル）
-  const dbuCount = nodes * dbuPerNode;
-
-  // 合計 USD
-  const totalUSD = (dbuRateUSD * dbuCount + vmRateUSD * nodes) * hours;
-
-  // リージョン乗数を適用（例: 料金に地域係数を掛ける）
-  const regionMultiplier = region.multiplier || 1.0;
-  const totalUSDAdjusted = totalUSD * regionMultiplier;
-
-  const exchange = (pricingData.exchange && pricingData.exchange.USDJPY) || 150;
-  const totalJPY = totalUSDAdjusted * exchange;
-
-  // 内訳
-  const dbuCostUSD = dbuRateUSD * dbuCount * hours * regionMultiplier;
-  const vmCostUSD = vmRateUSD * nodes * hours * regionMultiplier;
-
-  totalPriceEl.textContent = formatYen(totalJPY);
-  breakdownEl.textContent =
-    `DBU: $${dbuCostUSD.toFixed(2)} / VM: $${vmCostUSD.toFixed(2)}  合計: $${(dbuCostUSD + vmCostUSD).toFixed(2)} (USD)  （為替 ${exchange} JPY = 1 USD）`;
+  element.textContent = `${label} ${value}`;
 }
 
-calcBtn.addEventListener('click', calculate);
-resetBtn.addEventListener('click', () => {
-  if (!pricingData) return;
-  workloadEl.value = Object.keys(pricingData.workloads)[0];
-  instanceEl.value = Object.keys(pricingData.instances)[0];
-  clusterEl.value = Object.keys(pricingData.clusters)[0];
-  regionEl.value = Object.keys(pricingData.regions)[0];
-  hoursEl.value = '1';
-  calculate();
-});
+function clearBanners() {
+  bannerContainer.innerHTML = '';
+}
 
-// 初期ロード
-loadPricing();
+function createBanner(type, message) {
+  const banner = document.createElement('div');
+  banner.className = `banner banner-${type}`;
+  const text = document.createElement('p');
+  text.textContent = message;
+  banner.appendChild(text);
+  bannerContainer.appendChild(banner);
+}
+
+function showError(message) {
+  clearBanners();
+  createBanner('error', message);
+}
+
+function disableInputs(disabled) {
+  [serviceSelect, editionSelect, regionSelect, serverlessSelect, dbuInput, calcBtn, resetBtn].forEach((element) => {
+    if (element) {
+      element.disabled = disabled;
+    }
+  });
+}
+
+function computeOptions(workloads, skipField) {
+  return workloads.reduce((set, record) => {
+    if (!matchesFilters(record, skipField)) {
+      return set;
+    }
+    const value = fieldValue(record, skipField);
+    if (value !== undefined && value !== null) {
+      set.add(value);
+    }
+    return set;
+  }, new Set());
+}
+
+function matchesFilters(record, skipField = null) {
+  return Object.entries(filterState).every(([field, value]) => {
+    if (field === skipField) {
+      return true;
+    }
+    if (!value && value !== false) {
+      return true;
+    }
+    if (field === 'serverless') {
+      return String(record.serverless) === value;
+    }
+    return record[field] === value;
+  });
+}
+
+function fieldValue(record, field) {
+  if (field === 'serverless') {
+    return String(record.serverless);
+  }
+  return record[field];
+}
+
+function populateSelect(selectElement, options, formatter) {
+  if (!selectElement) return;
+  const currentValue = selectElement.value;
+  selectElement.innerHTML = '';
+  options.forEach((option) => {
+    const opt = document.createElement('option');
+    opt.value = option;
+    opt.textContent = formatter(option);
+    selectElement.appendChild(opt);
+  });
+  if (options.includes(currentValue)) {
+    selectElement.value = currentValue;
+  } else if (options.length > 0) {
+    selectElement.value = options[0];
+    filterState[selectElement.dataset.field] = options[0];
+  }
+}
+
+function refreshSelectors() {
+  const workloads = pricingData.workloads;
+
+  const serviceOptions = Array.from(computeOptions(workloads, 'service')).sort();
+  populateSelect(serviceSelect, serviceOptions, (value) => value);
+  filterState.service = serviceSelect.value;
+
+  const editionOptions = Array.from(computeOptions(workloads, 'edition')).sort();
+  populateSelect(editionSelect, editionOptions, (value) => value);
+  filterState.edition = editionSelect.value;
+
+  const regionOptions = Array.from(computeOptions(workloads, 'region')).sort();
+  populateSelect(regionSelect, regionOptions, (value) => value);
+  filterState.region = regionSelect.value;
+
+  const serverlessOptions = Array.from(computeOptions(workloads, 'serverless')).sort();
+  populateSelect(serverlessSelect, serverlessOptions, (value) => (value === 'true' ? 'Serverless' : 'Dedicated'));
+  filterState.serverless = serverlessSelect.value;
+
+  updateCurrentRecord();
+}
+
+function updateCurrentRecord() {
+  if (!pricingData) {
+    return;
+  }
+  const match = pricingData.workloads.find((record) => matchesFilters(record));
+  currentRecord = match || null;
+  if (!currentRecord) {
+    selectedRateEl.textContent = '-- USD/DBU';
+    effectiveDateEl.textContent = '--';
+    sourceLinkEl.textContent = '--';
+    recordNotesEl.textContent = '';
+    breakdownEl.textContent = '該当するレコードがありません。条件を見直してください。';
+    totalPriceEl.textContent = formatCurrency(0);
+    dbuInput.disabled = true;
+    calcBtn.disabled = true;
+    return;
+  }
+  dbuInput.disabled = false;
+  calcBtn.disabled = false;
+
+  const currency = metadata?.currency || 'USD';
+  selectedRateEl.textContent = `${currentRecord.dbu_rate.toFixed(2)} ${currency}/DBU`;
+  effectiveDateEl.textContent = currentRecord.effective_from;
+  sourceLinkEl.innerHTML = '';
+  const link = document.createElement('a');
+  link.href = currentRecord.source;
+  link.target = '_blank';
+  link.rel = 'noopener noreferrer';
+  link.className = 'inline-link';
+  link.textContent = '表示';
+  link.title = currentRecord.source;
+  sourceLinkEl.appendChild(link);
+
+  recordNotesEl.textContent = currentRecord.notes || '';
+  calculate();
+}
+
+function calculate() {
+  if (!currentRecord) {
+    totalPriceEl.textContent = formatCurrency(0);
+    breakdownEl.textContent = '該当するレコードがありません。';
+    return;
+  }
+  const dbuUsage = Math.max(0, Number.parseFloat(dbuInput.value) || 0);
+  const total = currentRecord.dbu_rate * dbuUsage;
+  const currency = metadata?.currency || 'USD';
+
+  totalPriceEl.textContent = formatCurrency(total);
+  breakdownEl.textContent = `DBU 単価 ${currentRecord.dbu_rate.toFixed(2)} ${currency}/DBU × DBU 使用量 ${dbuUsage.toLocaleString()} = ${formatCurrency(total)}`;
+  saveUiState();
+}
+
+function attachListeners() {
+  serviceSelect.dataset.field = 'service';
+  editionSelect.dataset.field = 'edition';
+  regionSelect.dataset.field = 'region';
+  serverlessSelect.dataset.field = 'serverless';
+
+  [serviceSelect, editionSelect, regionSelect, serverlessSelect].forEach((select) => {
+    select.addEventListener('change', () => {
+      filterState[select.dataset.field] = select.value;
+      refreshSelectors();
+    });
+  });
+
+  dbuInput.addEventListener('input', () => {
+    calculate();
+  });
+
+  calcBtn.addEventListener('click', () => {
+    calculate();
+  });
+
+  resetBtn.addEventListener('click', () => {
+    filterState.service = '';
+    filterState.edition = '';
+    filterState.region = '';
+    filterState.serverless = '';
+    dbuInput.value = 1000;
+    refreshSelectors();
+    calculate();
+  });
+}
+
+async function initialize() {
+  try {
+    const result = await loadPricingData();
+    pricingData = result.data;
+    metadata = result.metadata;
+
+    setBadgeText(versionBadge, 'version', metadata.version);
+    setBadgeText(currencyBadge, 'currency', metadata.currency);
+
+    restoreUiState();
+    attachListeners();
+    refreshSelectors();
+
+    clearBanners();
+    if (result.issues && result.issues.length > 0) {
+      const summary = summarizeIssues(result.issues);
+      if (metadata.fromCache) {
+        const storedAt = metadata.storedAt ? `保存時刻: ${metadata.storedAt}` : '保存済みデータを使用しています';
+        createBanner('info', `最新の pricing.json の検証に失敗したため、${storedAt}。\n${summary}`);
+      } else {
+        createBanner('error', summary);
+      }
+    } else if (metadata.usedLegacyConversion) {
+      createBanner('info', '旧フォーマットの pricing.json を検出したため、正規化データに変換して使用しています。');
+    }
+  } catch (error) {
+    console.error(error);
+    showError(`料金データの読み込みに失敗しました: ${error.message}`);
+    disableInputs(true);
+  }
+}
+
+initialize();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "azure-databricks-pricing",
+  "version": "0.1.0",
+  "description": "Azure Databricks Pricing Simulator Orange",
+  "type": "module",
+  "scripts": {
+    "test": "node --test",
+    "validate:pricing": "node scripts/validate-pricing.mjs"
+  }
+}

--- a/pricing.json
+++ b/pricing.json
@@ -1,58 +1,104 @@
 {
+  "version": "2024-09-20",
   "currency": "USD",
-  "exchange": {
-    "USDJPY": 150
-  },
-  "workloads": {
-    "all-purpose": {
-      "label": "All-purpose（対話型）",
-      "dbu_rates": {
-        "Standard_DS3_v2": 0.15,
-        "Standard_DS4_v2": 0.28,
-        "Standard_DS5_v2": 0.50
-      }
+  "notes": "DBU platform rates only. Infrastructure (VM/Storage/Egress) to be modelled separately.",
+  "workloads": [
+    {
+      "cloud": "Azure",
+      "region": "japaneast",
+      "edition": "Premium",
+      "service": "Jobs Compute",
+      "serverless": false,
+      "dbu_rate": 0.23,
+      "source": "https://www.databricks.com/product/azure-pricing",
+      "effective_from": "2024-08-01",
+      "notes": "Estimated list rate for Premium Jobs in Japan East."
     },
-    "job": {
-      "label": "Job（バッチ）",
-      "dbu_rates": {
-        "Standard_DS3_v2": 0.11,
-        "Standard_DS4_v2": 0.20,
-        "Standard_DS5_v2": 0.36
-      }
+    {
+      "cloud": "Azure",
+      "region": "eastus",
+      "edition": "Premium",
+      "service": "Jobs Compute",
+      "serverless": false,
+      "dbu_rate": 0.20,
+      "source": "https://www.databricks.com/product/azure-pricing",
+      "effective_from": "2024-08-01",
+      "notes": "Reference workload for East US."
     },
-    "sql": {
-      "label": "SQL（クエリ）",
-      "dbu_rates": {
-        "Standard_DS3_v2": 0.09,
-        "Standard_DS4_v2": 0.16,
-        "Standard_DS5_v2": 0.30
-      }
+    {
+      "cloud": "Azure",
+      "region": "japaneast",
+      "edition": "Premium",
+      "service": "All-Purpose Compute",
+      "serverless": false,
+      "dbu_rate": 0.30,
+      "source": "https://www.databricks.com/product/azure-pricing",
+      "effective_from": "2024-08-01",
+      "notes": "Interactive cluster example."
+    },
+    {
+      "cloud": "Azure",
+      "region": "eastus",
+      "edition": "Premium",
+      "service": "All-Purpose Compute",
+      "serverless": false,
+      "dbu_rate": 0.27,
+      "source": "https://www.databricks.com/product/azure-pricing",
+      "effective_from": "2024-08-01"
+    },
+    {
+      "cloud": "Azure",
+      "region": "japaneast",
+      "edition": "Premium",
+      "service": "Delta Live Tables",
+      "serverless": false,
+      "dbu_rate": 0.35,
+      "source": "https://www.databricks.com/product/azure-pricing",
+      "effective_from": "2024-08-01",
+      "notes": "Pipeline edition cost"
+    },
+    {
+      "cloud": "Azure",
+      "region": "eastus",
+      "edition": "Premium",
+      "service": "Serverless SQL",
+      "serverless": true,
+      "dbu_rate": 0.44,
+      "source": "https://www.databricks.com/product/azure-databricks-serverless-sql",
+      "effective_from": "2024-07-15",
+      "notes": "Serverless SQL baseline."
+    },
+    {
+      "cloud": "Azure",
+      "region": "westeurope",
+      "edition": "Premium",
+      "service": "Serverless SQL",
+      "serverless": true,
+      "dbu_rate": 0.46,
+      "source": "https://www.databricks.com/product/azure-databricks-serverless-sql",
+      "effective_from": "2024-07-15"
+    },
+    {
+      "cloud": "Azure",
+      "region": "eastus",
+      "edition": "Standard",
+      "service": "Jobs Compute",
+      "serverless": false,
+      "dbu_rate": 0.16,
+      "source": "https://www.databricks.com/product/azure-pricing",
+      "effective_from": "2024-08-01",
+      "notes": "Standard edition discounted rate."
+    },
+    {
+      "cloud": "Azure",
+      "region": "eastus",
+      "edition": "Premium",
+      "service": "Model Serving",
+      "serverless": true,
+      "dbu_rate": 0.65,
+      "source": "https://www.databricks.com/product/machine-learning/model-serving",
+      "effective_from": "2024-09-01",
+      "notes": "Preview guidance for managed serving."
     }
-  },
-  "instances": {
-    "Standard_DS3_v2": {
-      "label": "Standard_DS3_v2",
-      "vm_rate": 0.40,
-      "dbu_per_node": 4
-    },
-    "Standard_DS4_v2": {
-      "label": "Standard_DS4_v2",
-      "vm_rate": 0.80,
-      "dbu_per_node": 8
-    },
-    "Standard_DS5_v2": {
-      "label": "Standard_DS5_v2",
-      "vm_rate": 1.60,
-      "dbu_per_node": 16
-    }
-  },
-  "clusters": {
-    "small": { "label": "Small", "nodes": 2 },
-    "medium": { "label": "Medium", "nodes": 4 },
-    "large": { "label": "Large", "nodes": 8 }
-  },
-  "regions": {
-    "jp-east": { "label": "Japan East", "multiplier": 1.0 },
-    "eastus": { "label": "East US", "multiplier": 0.95 }
-  }
+  ]
 }

--- a/schema/pricing.schema.json
+++ b/schema/pricing.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Azure Databricks Pricing Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "currency", "workloads"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[0-9A-Za-z_.:-]+$"
+    },
+    "currency": {
+      "type": "string",
+      "pattern": "^[A-Z]{3}$"
+    },
+    "notes": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2048
+    },
+    "workloads": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "cloud",
+          "region",
+          "edition",
+          "service",
+          "serverless",
+          "dbu_rate",
+          "source",
+          "effective_from"
+        ],
+        "properties": {
+          "cloud": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64
+          },
+          "region": {
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "edition": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64
+          },
+          "service": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+          },
+          "serverless": {
+            "type": "boolean"
+          },
+          "dbu_rate": {
+            "type": "number",
+            "minimum": 0
+          },
+          "source": {
+            "type": "string",
+            "format": "uri",
+            "minLength": 1,
+            "maxLength": 2048
+          },
+          "effective_from": {
+            "type": "string",
+            "format": "date"
+          },
+          "notes": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 2048
+          }
+        }
+      }
+    },
+    "infra": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/scripts/validate-pricing.mjs
+++ b/scripts/validate-pricing.mjs
@@ -1,0 +1,47 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { compileSchema, formatErrors } from '../src/lib/json-schema-validator.js';
+import { detectDuplicateWorkloads } from '../src/lib/workload-utils.js';
+
+function resolveRelative(relativePath) {
+  const currentDir = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(currentDir, '..', relativePath);
+}
+
+async function main() {
+  try {
+    const schemaPath = resolveRelative('schema/pricing.schema.json');
+    const dataPath = resolveRelative('pricing.json');
+
+    const [schemaRaw, dataRaw] = await Promise.all([
+      readFile(schemaPath, 'utf8'),
+      readFile(dataPath, 'utf8')
+    ]);
+
+    const schema = JSON.parse(schemaRaw);
+    const data = JSON.parse(dataRaw);
+
+    const validator = compileSchema(schema);
+    if (!validator(data)) {
+      console.error('pricing.json failed schema validation');
+      console.error(formatErrors(validator.errors));
+      process.exit(1);
+    }
+
+    const duplicates = detectDuplicateWorkloads(data.workloads || []);
+    if (duplicates.length > 0) {
+      console.error('pricing.json contains duplicate workload definitions');
+      duplicates.forEach((issue) => console.error(`- ${issue}`));
+      process.exit(1);
+    }
+
+    console.log('pricing.json validation passed');
+  } catch (error) {
+    console.error('Unable to validate pricing.json');
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+await main();

--- a/src/lib/json-schema-validator.js
+++ b/src/lib/json-schema-validator.js
@@ -1,0 +1,226 @@
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+function isObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function pushError(errors, path, message) {
+  errors.push({
+    instancePath: path,
+    message
+  });
+}
+
+function checkType(schemaType, data, path, errors) {
+  if (!schemaType) {
+    return true;
+  }
+  const types = Array.isArray(schemaType) ? schemaType : [schemaType];
+  for (const type of types) {
+    switch (type) {
+      case 'string':
+        if (typeof data === 'string') return true;
+        break;
+      case 'number':
+        if (typeof data === 'number' && Number.isFinite(data)) return true;
+        break;
+      case 'integer':
+        if (Number.isInteger(data)) return true;
+        break;
+      case 'boolean':
+        if (typeof data === 'boolean') return true;
+        break;
+      case 'object':
+        if (isObject(data)) return true;
+        break;
+      case 'array':
+        if (Array.isArray(data)) return true;
+        break;
+      case 'null':
+        if (data === null) return true;
+        break;
+      default:
+        break;
+    }
+  }
+  pushError(errors, path, `expected type ${types.join(', ')}`);
+  return false;
+}
+
+function checkStringConstraints(schema, data, path, errors) {
+  if (typeof data !== 'string') {
+    return;
+  }
+  if (schema.minLength !== undefined && data.length < schema.minLength) {
+    pushError(errors, path, `should NOT be shorter than ${schema.minLength} characters`);
+  }
+  if (schema.maxLength !== undefined && data.length > schema.maxLength) {
+    pushError(errors, path, `should NOT be longer than ${schema.maxLength} characters`);
+  }
+  if (schema.pattern) {
+    const pattern = new RegExp(schema.pattern);
+    if (!pattern.test(data)) {
+      pushError(errors, path, `should match pattern ${schema.pattern}`);
+    }
+  }
+  if (schema.format) {
+    switch (schema.format) {
+      case 'uri':
+        try {
+          // eslint-disable-next-line no-new
+          new URL(data);
+        } catch (error) {
+          pushError(errors, path, 'should match format uri');
+        }
+        break;
+      case 'date':
+        if (!DATE_REGEX.test(data)) {
+          pushError(errors, path, 'should match format date (YYYY-MM-DD)');
+        } else {
+          const [year, month, day] = data.split('-').map((value) => Number.parseInt(value, 10));
+          const candidate = new Date(Date.UTC(year, month - 1, day));
+          if (
+            candidate.getUTCFullYear() !== year ||
+            candidate.getUTCMonth() !== month - 1 ||
+            candidate.getUTCDate() !== day
+          ) {
+            pushError(errors, path, 'should be a valid calendar date');
+          }
+        }
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+function checkNumberConstraints(schema, data, path, errors) {
+  if (typeof data !== 'number') {
+    return;
+  }
+  if (schema.minimum !== undefined && data < schema.minimum) {
+    pushError(errors, path, `should be >= ${schema.minimum}`);
+  }
+  if (schema.maximum !== undefined && data > schema.maximum) {
+    pushError(errors, path, `should be <= ${schema.maximum}`);
+  }
+  if (schema.exclusiveMinimum !== undefined && data <= schema.exclusiveMinimum) {
+    pushError(errors, path, `should be > ${schema.exclusiveMinimum}`);
+  }
+  if (schema.exclusiveMaximum !== undefined && data >= schema.exclusiveMaximum) {
+    pushError(errors, path, `should be < ${schema.exclusiveMaximum}`);
+  }
+}
+
+function validateSchema(schema, data, path, errors) {
+  if (schema === true || schema === undefined) {
+    return;
+  }
+  if (schema === false) {
+    pushError(errors, path, 'value is not allowed');
+    return;
+  }
+
+  if (!checkType(schema.type, data, path, errors)) {
+    return;
+  }
+
+  if (schema.enum && !schema.enum.includes(data)) {
+    pushError(errors, path, `should be equal to one of the allowed values`);
+    return;
+  }
+
+  if (schema.const !== undefined && data !== schema.const) {
+    pushError(errors, path, 'should be equal to constant value');
+    return;
+  }
+
+  checkStringConstraints(schema, data, path, errors);
+  checkNumberConstraints(schema, data, path, errors);
+
+  if (schema.allOf) {
+    for (const subSchema of schema.allOf) {
+      validateSchema(subSchema, data, path, errors);
+    }
+  }
+  if (schema.anyOf) {
+    const originalLength = errors.length;
+    let matched = false;
+    for (const subSchema of schema.anyOf) {
+      const subErrors = [];
+      validateSchema(subSchema, data, path, subErrors);
+      if (subErrors.length === 0) {
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) {
+      pushError(errors, path, 'should match at least one schema in anyOf');
+    }
+    if (errors.length > originalLength) {
+      errors.splice(originalLength, errors.length - originalLength);
+    }
+  }
+
+  if (schema.type === 'object' && isObject(data)) {
+    const properties = schema.properties || {};
+    const required = schema.required || [];
+
+    for (const prop of required) {
+      if (!Object.prototype.hasOwnProperty.call(data, prop)) {
+        pushError(errors, `${path}/${prop}`, 'is required');
+      }
+    }
+
+    for (const [key, value] of Object.entries(data)) {
+      if (Object.prototype.hasOwnProperty.call(properties, key)) {
+        validateSchema(properties[key], value, `${path}/${key}`, errors);
+      } else if (schema.additionalProperties === false) {
+        pushError(errors, `${path}/${key}`, 'is not allowed');
+      } else if (isObject(schema.additionalProperties)) {
+        validateSchema(schema.additionalProperties, value, `${path}/${key}`, errors);
+      }
+    }
+  }
+
+  if (schema.type === 'array' && Array.isArray(data)) {
+    if (schema.minItems !== undefined && data.length < schema.minItems) {
+      pushError(errors, path, `should NOT have fewer than ${schema.minItems} items`);
+    }
+    if (schema.maxItems !== undefined && data.length > schema.maxItems) {
+      pushError(errors, path, `should NOT have more than ${schema.maxItems} items`);
+    }
+    if (schema.items) {
+      for (let index = 0; index < data.length; index += 1) {
+        const itemSchema = Array.isArray(schema.items)
+          ? schema.items[Math.min(index, schema.items.length - 1)]
+          : schema.items;
+        validateSchema(itemSchema, data[index], `${path}/${index}`, errors);
+      }
+    }
+  }
+}
+
+export function compileSchema(schema) {
+  function validator(data) {
+    const errors = [];
+    validateSchema(schema, data, '', errors);
+    validator.errors = errors;
+    return errors.length === 0;
+  }
+  validator.errors = [];
+  return validator;
+}
+
+export function formatErrors(errors) {
+  if (!errors || errors.length === 0) {
+    return 'unknown validation error';
+  }
+  return errors
+    .map((error) => {
+      const path = error.instancePath || '';
+      const label = path === '' ? '/' : path;
+      return `${label} ${error.message}`;
+    })
+    .join('; ');
+}

--- a/src/lib/workload-utils.js
+++ b/src/lib/workload-utils.js
@@ -1,0 +1,17 @@
+export function createWorkloadKey(record) {
+  return [record.cloud, record.region, record.edition, record.service, record.serverless].join('||');
+}
+
+export function detectDuplicateWorkloads(workloads = []) {
+  const duplicates = [];
+  const seen = new Map();
+  workloads.forEach((record, index) => {
+    const key = createWorkloadKey(record);
+    if (seen.has(key)) {
+      duplicates.push(`Duplicate workload combination detected for (${key}) at indexes ${seen.get(key)} and ${index}`);
+    } else {
+      seen.set(key, index);
+    }
+  });
+  return duplicates;
+}

--- a/src/pricing-loader.js
+++ b/src/pricing-loader.js
@@ -1,0 +1,232 @@
+import { compileSchema, formatErrors } from './lib/json-schema-validator.js';
+import { detectDuplicateWorkloads } from './lib/workload-utils.js';
+
+const PRICING_URL = 'pricing.json';
+const SCHEMA_URL = 'schema/pricing.schema.json';
+const LKG_STORAGE_KEY = 'orange:lastKnownGoodPricing';
+const LEGACY_SOURCE_URL = 'https://www.databricks.com/product/azure-databricks-pricing';
+
+class PricingValidationError extends Error {
+  constructor(message, issues) {
+    super(message);
+    this.name = 'PricingValidationError';
+    this.issues = issues;
+  }
+}
+
+class PricingLoadError extends Error {
+  constructor(message, issues) {
+    super(message);
+    this.name = 'PricingLoadError';
+    this.issues = issues;
+  }
+}
+
+let validatorPromise = null;
+
+async function getValidator() {
+  if (!validatorPromise) {
+    validatorPromise = fetch(SCHEMA_URL)
+      .then((response) => {
+        if (!response.ok) {
+          throw new PricingLoadError(`pricing schema fetch failed: ${response.status}`, [
+            `schema HTTP status ${response.status}`
+          ]);
+        }
+        return response.json();
+      })
+      .then((schema) => compileSchema(schema));
+  }
+  return validatorPromise;
+}
+
+function buildErrorMessages(errors) {
+  if (!errors) {
+    return [];
+  }
+  return errors.map((error) => {
+    const path = error.instancePath || '/';
+    const message = error.message || 'validation error';
+    return `${path} ${message}`;
+  });
+}
+
+function sanitizeRegionKey(regionKey) {
+  if (typeof regionKey !== 'string') {
+    return 'global';
+  }
+  return regionKey
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '') || 'global';
+}
+
+function convertLegacyPricing(data) {
+  const version = typeof data.version === 'string' && data.version.length > 0 ? data.version : 'legacy';
+  const currency = typeof data.currency === 'string' && data.currency.length > 0 ? data.currency : 'USD';
+  const regions = isObject(data.regions) ? Object.keys(data.regions) : ['global'];
+  const workloads = [];
+  const workloadEntries = isObject(data.workloads) ? Object.entries(data.workloads) : [];
+
+  for (const [workloadKey, workloadValue] of workloadEntries) {
+    const label = isObject(workloadValue) && typeof workloadValue.label === 'string'
+      ? workloadValue.label
+      : workloadKey;
+    const dbuRates = isObject(workloadValue) && isObject(workloadValue.dbu_rates)
+      ? Object.entries(workloadValue.dbu_rates)
+      : [];
+    for (const [instanceKey, rate] of dbuRates) {
+      const serviceName = `${label} / ${instanceKey}`;
+      for (const region of regions) {
+        workloads.push({
+          cloud: 'Azure',
+          region: sanitizeRegionKey(region),
+          edition: 'Legacy',
+          service: serviceName,
+          serverless: false,
+          dbu_rate: typeof rate === 'number' && Number.isFinite(rate) ? rate : 0,
+          source: LEGACY_SOURCE_URL,
+          effective_from: '1970-01-01',
+          notes: `Converted from legacy pricing.json (${workloadKey}/${instanceKey})`
+        });
+      }
+    }
+  }
+
+  if (workloads.length === 0) {
+    throw new PricingValidationError('Legacy pricing.json did not contain convertible records', [
+      'Legacy conversion yielded no workloads'
+    ]);
+  }
+
+  console.warn('pricing.json legacy format detected — converted to normalized schema');
+  return {
+    version,
+    currency,
+    notes: 'Converted from legacy pricing.json format',
+    workloads
+  };
+}
+
+function isLegacyFormat(data) {
+  if (!data) {
+    return false;
+  }
+  return !Array.isArray(data.workloads);
+}
+
+function isObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function storeLastKnownGood(payload) {
+  try {
+    const record = {
+      storedAt: new Date().toISOString(),
+      data: payload.data,
+      metadata: payload.metadata
+    };
+    window.localStorage.setItem(LKG_STORAGE_KEY, JSON.stringify(record));
+  } catch (error) {
+    console.warn('Failed to persist last known good pricing.json to localStorage', error);
+  }
+}
+
+function readLastKnownGood() {
+  try {
+    const raw = window.localStorage.getItem(LKG_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw);
+    if (!parsed || !parsed.data) {
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to read last known good pricing.json from localStorage', error);
+    return null;
+  }
+}
+
+async function fetchRemotePricing() {
+  const response = await fetch(PRICING_URL, { cache: 'no-store' });
+  if (!response.ok) {
+    throw new PricingLoadError(`pricing.json fetch failed: ${response.status}`, [
+      `pricing.json HTTP status ${response.status}`
+    ]);
+  }
+  return response.json();
+}
+
+export async function loadPricingData() {
+  const validator = await getValidator();
+  let issues = [];
+  let metadata = { fromCache: false, usedLegacyConversion: false };
+
+  try {
+    let rawData = await fetchRemotePricing();
+    if (isLegacyFormat(rawData)) {
+      rawData = convertLegacyPricing(rawData);
+      metadata.usedLegacyConversion = true;
+    }
+
+    const isValid = validator(rawData);
+    if (!isValid) {
+      issues = buildErrorMessages(validator.errors);
+      throw new PricingValidationError('pricing.json failed schema validation', issues);
+    }
+
+    const duplicateIssues = detectDuplicateWorkloads(rawData.workloads);
+    if (duplicateIssues.length > 0) {
+      issues = duplicateIssues;
+      throw new PricingValidationError('pricing.json contains duplicate workload definitions', issues);
+    }
+
+    metadata = {
+      ...metadata,
+      version: rawData.version,
+      currency: rawData.currency,
+      storedAt: new Date().toISOString()
+    };
+
+    storeLastKnownGood({ data: rawData, metadata });
+
+    return {
+      data: rawData,
+      metadata,
+      issues: []
+    };
+  } catch (error) {
+    if (error instanceof PricingValidationError || error instanceof PricingLoadError) {
+      issues = error.issues || issues;
+    } else {
+      issues = [error.message];
+    }
+
+    const cached = readLastKnownGood();
+    if (cached && cached.data) {
+      return {
+        data: cached.data,
+        metadata: {
+          ...cached.metadata,
+          fromCache: true
+        },
+        issues
+      };
+    }
+
+    throw new PricingLoadError('pricing data load failed', issues);
+  }
+}
+
+export function summarizeIssues(issues) {
+  if (!issues || issues.length === 0) {
+    return '';
+  }
+  return issues.join('\n');
+}
+
+export { formatErrors };

--- a/style.css
+++ b/style.css
@@ -42,6 +42,24 @@ header p{
   opacity:0.95;
   font-size:13px;
 }
+.pricing-meta{
+  margin-top:8px;
+  display:flex;
+  gap:8px;
+  flex-wrap:wrap;
+}
+.badge{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  padding:4px 8px;
+  border-radius:999px;
+  background:rgba(255,255,255,0.18);
+  border:1px solid rgba(255,255,255,0.3);
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:0.04em;
+}
 main{
   max-width:980px;
   margin:28px auto;
@@ -74,9 +92,20 @@ select,input[type="number"]{
   font-size:14px;
   background:white;
 }
+select:disabled,
+input:disabled{
+  background:#f5f5f5;
+  cursor:not-allowed;
+}
 .col{
   flex:1 1 220px;
   min-width:220px;
+}
+.metric{
+  font-size:16px;
+  font-weight:600;
+  color:#222;
+  word-break:break-all;
 }
 .actions{
   display:flex;
@@ -114,11 +143,53 @@ button.secondary{
   font-size:13px;
   color:var(--muted);
 }
+.banner{
+  padding:14px 16px;
+  border-radius:10px;
+  margin-bottom:16px;
+  display:flex;
+  justify-content:space-between;
+  gap:12px;
+  align-items:flex-start;
+}
+.banner p{
+  margin:0;
+  font-size:13px;
+}
+.banner-error{
+  background:#ffecec;
+  border-left:4px solid #e53935;
+  color:#8a1f1f;
+}
+.banner-info{
+  background:#fff7e6;
+  border-left:4px solid #ff9800;
+  color:#8a5200;
+}
+.banner button{
+  background:transparent;
+  color:inherit;
+  border:none;
+  padding:0;
+  font-size:12px;
+  text-decoration:underline;
+  cursor:pointer;
+}
+.hidden{
+  display:none !important;
+}
 footer{
   text-align:center;
   color:var(--muted);
   margin:18px 0 60px 0;
   font-size:13px;
+}
+a.inline-link{
+  color:var(--orange-dark);
+  text-decoration:none;
+}
+a.inline-link:hover{
+  text-decoration:underline;
 }
 
 /* responsive */
@@ -126,4 +197,5 @@ footer{
   header{padding:18px;}
   .col{min-width:100%;}
   .result{flex-direction:column;align-items:flex-start;}
+  .badge{text-transform:none;font-size:11px;}
 }

--- a/tests/pricing-schema.test.js
+++ b/tests/pricing-schema.test.js
@@ -1,0 +1,121 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { compileSchema, formatErrors } from '../src/lib/json-schema-validator.js';
+import { detectDuplicateWorkloads } from '../src/lib/workload-utils.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const schemaPath = path.resolve(__dirname, '../schema/pricing.schema.json');
+const schemaContent = await readFile(schemaPath, 'utf8');
+const schema = JSON.parse(schemaContent);
+
+function validate(data) {
+  const validator = compileSchema(schema);
+  const valid = validator(data);
+  return { valid, errors: validator.errors };
+}
+
+test('pricing.json matches the schema and uniqueness constraints', async () => {
+  const pricingPath = path.resolve(__dirname, '../pricing.json');
+  const json = JSON.parse(await readFile(pricingPath, 'utf8'));
+  const result = validate(json);
+  assert.equal(result.valid, true, formatErrors(result.errors));
+  const duplicates = detectDuplicateWorkloads(json.workloads || []);
+  assert.equal(duplicates.length, 0, duplicates.join('; '));
+});
+
+test('negative dbu_rate is rejected', () => {
+  const sample = {
+    version: '2024-01-01',
+    currency: 'USD',
+    workloads: [
+      {
+        cloud: 'Azure',
+        region: 'eastus',
+        edition: 'Premium',
+        service: 'Jobs Compute',
+        serverless: false,
+        dbu_rate: -0.1,
+        source: 'https://example.com',
+        effective_from: '2024-01-01'
+      }
+    ]
+  };
+  const result = validate(sample);
+  assert.equal(result.valid, false, 'Negative rates must fail validation');
+});
+
+test('missing required field causes validation error', () => {
+  const sample = {
+    version: '2024-01-01',
+    currency: 'USD',
+    workloads: [
+      {
+        cloud: 'Azure',
+        region: 'eastus',
+        edition: 'Premium',
+        serverless: false,
+        dbu_rate: 0.1,
+        source: 'https://example.com',
+        effective_from: '2024-01-01'
+      }
+    ]
+  };
+  const result = validate(sample);
+  assert.equal(result.valid, false, 'Records without service should fail');
+});
+
+test('invalid effective_from date is rejected', () => {
+  const sample = {
+    version: '2024-01-01',
+    currency: 'USD',
+    workloads: [
+      {
+        cloud: 'Azure',
+        region: 'eastus',
+        edition: 'Premium',
+        service: 'Jobs Compute',
+        serverless: false,
+        dbu_rate: 0.1,
+        source: 'https://example.com',
+        effective_from: '2024-13-01'
+      }
+    ]
+  };
+  const result = validate(sample);
+  assert.equal(result.valid, false, 'Invalid dates must fail validation');
+});
+
+test('duplicate workloads are detected', () => {
+  const sample = {
+    version: '2024-01-01',
+    currency: 'USD',
+    workloads: [
+      {
+        cloud: 'Azure',
+        region: 'eastus',
+        edition: 'Premium',
+        service: 'Jobs Compute',
+        serverless: false,
+        dbu_rate: 0.1,
+        source: 'https://example.com',
+        effective_from: '2024-01-01'
+      },
+      {
+        cloud: 'Azure',
+        region: 'eastus',
+        edition: 'Premium',
+        service: 'Jobs Compute',
+        serverless: false,
+        dbu_rate: 0.12,
+        source: 'https://example.com',
+        effective_from: '2024-01-01'
+      }
+    ]
+  };
+  const duplicates = detectDuplicateWorkloads(sample.workloads);
+  assert.equal(duplicates.length, 1, 'Duplicates should be reported');
+});


### PR DESCRIPTION
## Summary
- normalize `pricing.json` to a workload-per-record format and describe it via `schema/pricing.schema.json`
- add a browser loader with schema validation, uniqueness checks, legacy conversion, and Last Known Good fallback logic
- refresh the simulator UI to surface version/currency badges, dynamic selectors, DBU-only costing, and banner messaging
- wire up Node-based validation scripts, unit tests, and a GitHub Actions workflow for automated checks

## Testing
- npm run validate:pricing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce0c074a74832f8eaa8d9428356cd3