### PR TITLE
Update app name references to Azure Databricks Pricing Simulator Orange

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Azure Databricks Pricing Orange</title>
+  <title>Azure Databricks Pricing Simulator Orange</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <header>
     <div class="logo">O</div>
     <div>
-      <h1>Azure Databricks Pricing Orange</h1>
+      <h1>Azure Databricks Pricing Simulator Orange</h1>
       <p>DBU プラットフォーム費用の概算を正規化データから算出します。</p>
       <div class="pricing-meta" id="pricingMeta">
         <span class="badge" id="pricingVersion">version --</span>


### PR DESCRIPTION
## Summary
- update the document title and header to use the name "Azure Databricks Pricing Simulator Orange"

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce1c75dc3c832fb9dc513e79837a2d